### PR TITLE
Default Model Fallback to Unconfigured Model

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -194,15 +194,28 @@ function getModelConfig(model: string): ModelConfig | null {
 // Default Model Helper
 // =============================================================================
 function getDefaultOrFirstModel(): string {
-  if (process.env.DEFAULT_MODEL) return process.env.DEFAULT_MODEL;
   const availableModels = Object.keys(MODELS);
   if (availableModels.length === 0) {
     throw new Error(
       "No AI providers configured. Please set up at least one provider in your environment.",
     );
   }
+  
+  // Validate DEFAULT_MODEL if set
+  if (process.env.DEFAULT_MODEL) {
+    if (MODELS[process.env.DEFAULT_MODEL]) {
+      return process.env.DEFAULT_MODEL;
+    }
+    console.warn(
+      `DEFAULT_MODEL "${process.env.DEFAULT_MODEL}" not found in configured models. Falling back to first available model: ${availableModels[0]}`
+    );
+  }
+  
   return availableModels[0];
 }
+
+// Resolve and validate the fallback model at startup
+const FALLBACK_MODEL = getDefaultOrFirstModel();
 
 // =============================================================================
 // Swagger Configuration
@@ -601,7 +614,7 @@ app.get("/models", (req, res) => {
  *                 example: "Make it more engaging and professional"
  *               model:
  *                 type: string
- *                 description: AI model to use (defaults to first available model)
+ *                 description: AI model to use. If not specified, uses the DEFAULT_MODEL environment variable if set and valid, otherwise falls back to the first configured model.
  *                 example: "gpt-4o"
  *     responses:
  *       200:
@@ -694,7 +707,7 @@ app.post("/enhance", authenticate, async (req, res) => {
       fullPrompt = `${fullPrompt}. Additional instructions: ${customPrompt}`;
     }
 
-    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
+    const chatModel = model || FALLBACK_MODEL;
     const systemPrompt = `You are a writing enhancement assistant. Your ONLY task is to improve the provided text according to the instruction. Return ONLY the enhanced text, nothing else. Do not include any explanations, meta-commentary, or the original instruction in your response. Output only the improved version of the text.`;
 
     const userMessage = `<instruction>
@@ -747,7 +760,7 @@ Return ONLY the enhanced content. Do not include the instruction text itself in 
  *                 example: "Translate to Spanish and make it formal"
  *               model:
  *                 type: string
- *                 description: AI model to use (defaults to first available model)
+ *                 description: AI model to use. If not specified, uses the DEFAULT_MODEL environment variable if set and valid, otherwise falls back to the first configured model.
  *                 example: "claude-3-5-sonnet"
  *     responses:
  *       200:
@@ -822,7 +835,7 @@ app.post("/custom", authenticate, async (req, res) => {
       return res.status(400).json({ error: "Text and prompt are required" });
     }
 
-    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
+    const chatModel = model || FALLBACK_MODEL;
     const systemPrompt = `You are a text processing assistant. Your task is to process text according to specific instructions. Return ONLY the result. Do not include explanations, instructions, or any meta-commentary. Output only the processed text.`;
 
     const userMessage = `<task>
@@ -932,7 +945,7 @@ app.post("/enhance/rewrite", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
+    const chatModel = model || FALLBACK_MODEL;
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.rewrite, text);
     res.json(result);
   } catch (error: unknown) {
@@ -988,7 +1001,7 @@ app.post("/enhance/summarize", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
+    const chatModel = model || FALLBACK_MODEL;
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.summarize, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1044,7 +1057,7 @@ app.post("/enhance/humanize", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
+    const chatModel = model || FALLBACK_MODEL;
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.humanize, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1100,7 +1113,7 @@ app.post("/enhance/grammar", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
+    const chatModel = model || FALLBACK_MODEL;
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.grammar, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1156,7 +1169,7 @@ app.post("/enhance/formal", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
+    const chatModel = model || FALLBACK_MODEL;
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.formal, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1214,7 +1227,7 @@ app.post("/enhance/casual", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
+    const chatModel = model || FALLBACK_MODEL;
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.casual, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1272,7 +1285,7 @@ app.post("/enhance/academic", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
+    const chatModel = model || FALLBACK_MODEL;
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.academic, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1330,7 +1343,7 @@ app.post("/enhance/seo", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
+    const chatModel = model || FALLBACK_MODEL;
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.seo, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1386,7 +1399,7 @@ app.post("/enhance/persuasive", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
+    const chatModel = model || FALLBACK_MODEL;
     const result = await chatWithAI(
       chatModel,
       DEFAULT_PROMPTS.persuasive,
@@ -1446,7 +1459,7 @@ app.post("/enhance/creative", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
+    const chatModel = model || FALLBACK_MODEL;
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.creative, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1502,7 +1515,7 @@ app.post("/enhance/twitter", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
+    const chatModel = model || FALLBACK_MODEL;
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.twitter, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1560,7 +1573,7 @@ app.post("/enhance/linkedin", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
+    const chatModel = model || FALLBACK_MODEL;
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.linkedin, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1618,7 +1631,7 @@ app.post("/enhance/story", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
+    const chatModel = model || FALLBACK_MODEL;
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.story, text);
     res.json(result);
   } catch (error: unknown) {

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -191,6 +191,20 @@ function getModelConfig(model: string): ModelConfig | null {
 }
 
 // =============================================================================
+// Default Model Helper
+// =============================================================================
+function getDefaultOrFirstModel(): string {
+  if (process.env.DEFAULT_MODEL) return process.env.DEFAULT_MODEL;
+  const availableModels = Object.keys(MODELS);
+  if (availableModels.length === 0) {
+    throw new Error(
+      "No AI providers configured. Please set up at least one provider in your environment.",
+    );
+  }
+  return availableModels[0];
+}
+
+// =============================================================================
 // Swagger Configuration
 // =============================================================================
 
@@ -587,7 +601,7 @@ app.get("/models", (req, res) => {
  *                 example: "Make it more engaging and professional"
  *               model:
  *                 type: string
- *                 description: AI model to use (defaults to MiniMax-M2.1)
+ *                 description: AI model to use (defaults to first available model)
  *                 example: "gpt-4o"
  *     responses:
  *       200:
@@ -680,7 +694,7 @@ app.post("/enhance", authenticate, async (req, res) => {
       fullPrompt = `${fullPrompt}. Additional instructions: ${customPrompt}`;
     }
 
-    const chatModel = model || process.env.DEFAULT_MODEL || "MiniMax-M2.1";
+    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
     const systemPrompt = `You are a writing enhancement assistant. Your ONLY task is to improve the provided text according to the instruction. Return ONLY the enhanced text, nothing else. Do not include any explanations, meta-commentary, or the original instruction in your response. Output only the improved version of the text.`;
 
     const userMessage = `<instruction>
@@ -733,7 +747,7 @@ Return ONLY the enhanced content. Do not include the instruction text itself in 
  *                 example: "Translate to Spanish and make it formal"
  *               model:
  *                 type: string
- *                 description: AI model to use (defaults to MiniMax-M2.1)
+ *                 description: AI model to use (defaults to first available model)
  *                 example: "claude-3-5-sonnet"
  *     responses:
  *       200:
@@ -808,7 +822,7 @@ app.post("/custom", authenticate, async (req, res) => {
       return res.status(400).json({ error: "Text and prompt are required" });
     }
 
-    const chatModel = model || process.env.DEFAULT_MODEL || "MiniMax-M2.1";
+    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
     const systemPrompt = `You are a text processing assistant. Your task is to process text according to specific instructions. Return ONLY the result. Do not include explanations, instructions, or any meta-commentary. Output only the processed text.`;
 
     const userMessage = `<task>
@@ -918,7 +932,7 @@ app.post("/enhance/rewrite", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || "MiniMax-M2.1";
+    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.rewrite, text);
     res.json(result);
   } catch (error: unknown) {
@@ -974,7 +988,7 @@ app.post("/enhance/summarize", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || "MiniMax-M2.1";
+    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.summarize, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1030,7 +1044,7 @@ app.post("/enhance/humanize", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || "MiniMax-M2.1";
+    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.humanize, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1086,7 +1100,7 @@ app.post("/enhance/grammar", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || "MiniMax-M2.1";
+    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.grammar, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1142,7 +1156,7 @@ app.post("/enhance/formal", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || "MiniMax-M2.1";
+    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.formal, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1200,7 +1214,7 @@ app.post("/enhance/casual", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || "MiniMax-M2.1";
+    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.casual, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1258,7 +1272,7 @@ app.post("/enhance/academic", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || "MiniMax-M2.1";
+    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.academic, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1316,7 +1330,7 @@ app.post("/enhance/seo", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || "MiniMax-M2.1";
+    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.seo, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1372,7 +1386,7 @@ app.post("/enhance/persuasive", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || "MiniMax-M2.1";
+    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
     const result = await chatWithAI(
       chatModel,
       DEFAULT_PROMPTS.persuasive,
@@ -1432,7 +1446,7 @@ app.post("/enhance/creative", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || "MiniMax-M2.1";
+    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.creative, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1488,7 +1502,7 @@ app.post("/enhance/twitter", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || "MiniMax-M2.1";
+    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.twitter, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1546,7 +1560,7 @@ app.post("/enhance/linkedin", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || "MiniMax-M2.1";
+    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.linkedin, text);
     res.json(result);
   } catch (error: unknown) {
@@ -1604,7 +1618,7 @@ app.post("/enhance/story", authenticate, async (req, res) => {
     if (!text) {
       return res.status(400).json({ error: "Text is required" });
     }
-    const chatModel = model || process.env.DEFAULT_MODEL || "MiniMax-M2.1";
+    const chatModel = model || process.env.DEFAULT_MODEL || getDefaultOrFirstModel();
     const result = await chatWithAI(chatModel, DEFAULT_PROMPTS.story, text);
     res.json(result);
   } catch (error: unknown) {

--- a/extension/src/popup/index.tsx
+++ b/extension/src/popup/index.tsx
@@ -110,13 +110,19 @@ export default function Popup() {
       return;
     }
 
+    const modelToUse = model || settings.defaultModel;
+    if (!modelToUse) {
+      setError("No model available. Please configure an AI provider.");
+      return;
+    }
+
     setLoading(true);
     setError("");
     setOutput("");
     setTokenUsage(null);
 
     try {
-      const result = await enhanceText(input, mode, settings, model);
+      const result = await enhanceText(input, mode, settings, modelToUse);
       setOutput(result.result);
       setTokenUsage(result.usage?.total_tokens || null);
 
@@ -125,7 +131,7 @@ export default function Popup() {
           originalText: input,
           enhancedText: result.result,
           mode,
-          model: model || settings.defaultModel,
+          model: modelToUse,
         });
       }
     } catch (err) {

--- a/extension/src/popup/index.tsx
+++ b/extension/src/popup/index.tsx
@@ -110,7 +110,22 @@ export default function Popup() {
       return;
     }
 
-    const modelToUse = model || settings.defaultModel;
+    // Handle loading state separately
+    if (modelsLoading) {
+      setError("Models are still loading. Please wait...");
+      return;
+    }
+
+    // Resolve effective model by validating against available models
+    const availableModelNames = settings.availableModels.map((m) => m.value);
+    let modelToUse = "";
+    
+    if (model && availableModelNames.includes(model)) {
+      modelToUse = model;
+    } else if (settings.defaultModel && availableModelNames.includes(settings.defaultModel)) {
+      modelToUse = settings.defaultModel;
+    }
+
     if (!modelToUse) {
       setError("No model available. Please configure an AI provider.");
       return;


### PR DESCRIPTION
## Description

Fixes #4

This PR addresses the issue where the API defaults to MiniMax-M2.1 which may not be configured, causing all API calls to fail with a generic error.

## Changes Made

### Backend (api/src/server.ts)
Added getDefaultOrFirstModel() helper function that uses DEFAULT_MODEL env var if set, falls back to first available configured model, and throws clear error if no providers configured. Replaced all 15 occurrences of hardcoded MiniMax-M2.1 fallback with getDefaultOrFirstModel(). Updated Swagger API documentation.

### Frontend (extension/src/popup/index.tsx)
Added validation before enhancement to check if model is available and show clear error message if none exists.

## Testing

1. Clone this branch
2. Set up .env with only OPENAI_API_KEY
3. Run yarn dev:api
4. Call /enhance without specifying a model
5. Expected: Uses first configured model (e.g., gpt-4o)

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  - Enhanced model selection logic to support dynamic defaults based on environment configuration
  - Updated API documentation to reflect revised default model behavior for endpoints

* **Bug Fixes**
  - Added error handling and early termination when no configured models are available
  - Improved consistency of model selection across multiple enhancement operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->